### PR TITLE
added with statement to np.load

### DIFF
--- a/sigver/datasets/util.py
+++ b/sigver/datasets/util.py
@@ -26,9 +26,9 @@ def load_dataset(path: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Dict, n
     -------
 
     """
-    data = np.load(path)
-    x, y, yforg = data['x'], data['y'], data['yforg']
-    user_mapping, filenames = data['user_mapping'], data['filenames']
+    with np.load(path) as data:
+        x, y, yforg = data['x'], data['y'], data['yforg']
+        user_mapping, filenames = data['user_mapping'], data['filenames']
 
     return x, y, yforg, user_mapping, filenames
 


### PR DESCRIPTION
closes the underlying file descriptor, preventing descriptor leak according to doc. https://docs.scipy.org/doc/numpy/reference/generated/numpy.load.html