### PR TITLE
numpy allow pickle compatibility

### DIFF
--- a/sigver/datasets/util.py
+++ b/sigver/datasets/util.py
@@ -26,7 +26,7 @@ def load_dataset(path: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Dict, n
     -------
 
     """
-    with np.load(path) as data:
+    with np.load(path, allow_pickle=True) as data:
         x, y, yforg = data['x'], data['y'], data['yforg']
         user_mapping, filenames = data['user_mapping'], data['filenames']
 


### PR DESCRIPTION
some versions do not default to allow_pickle=True, contrary to the documentation.
https://docs.scipy.org/doc/numpy/reference/generated/numpy.load.html